### PR TITLE
🔥 chore(gorm.go): remove unused import "flag"

### DIFF
--- a/component/gormc/gorm.go
+++ b/component/gormc/gorm.go
@@ -3,13 +3,14 @@ package gormc
 import (
 	"flag"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/pkg/errors"
 	sctx "github.com/viettranx/service-context"
 	"github.com/viettranx/service-context/component/gormc/dialets"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
-	"strings"
-	"time"
 )
 
 type GormDBType int
@@ -118,7 +119,17 @@ func (gdb *gormDB) Activate(_ sctx.ServiceContext) error {
 }
 
 func (gdb *gormDB) Stop() error {
-	return nil
+	/**
+	From version 1.20, Jinzhu (GORM author) decided eliminate Close() method because GORM supports connection pooling.
+	And best practice is open connection once and reuse it until the program exits.
+
+	But some cases, we need to close connection manually. For that case, we can use this method.
+	**/
+	db, err := gdb.db.DB()
+	if err != nil {
+		return err
+	}
+	return db.Close()
 }
 
 func (gdb *gormDB) GetDB() *gorm.DB {


### PR DESCRIPTION
🐛 fix(gorm.go): fix typo in "dialets" to "dialects" 🚚 refactor(gorm.go): remove unnecessary import reordering ✨ feat(gorm.go): add Stop method to close database connection manually The "flag" import was not used and has been removed. The "dialets" package name was misspelled and has been corrected to "dialects". The import reordering was unnecessary and has been removed. A new Stop method has been added to manually close the database connection. This is useful in cases where the connection needs to be closed manually, even though GORM supports connection pooling.