### PR TITLE
🐛 fix(gorm.go): add Stop method to close database connection manually

### DIFF
--- a/component/gormc/gorm.go
+++ b/component/gormc/gorm.go
@@ -3,13 +3,14 @@ package gormc
 import (
 	"flag"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/pkg/errors"
 	sctx "github.com/viettranx/service-context"
 	"github.com/viettranx/service-context/component/gormc/dialets"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
-	"strings"
-	"time"
 )
 
 type GormDBType int
@@ -118,7 +119,16 @@ func (gdb *gormDB) Activate(_ sctx.ServiceContext) error {
 }
 
 func (gdb *gormDB) Stop() error {
-	return nil
+	/**
+	From version 1.20, Jinzhu (GORM author) decided eliminate Close() method because GORM supports connection pooling.
+	And best practice is open connection once and reuse it until the program exits.
+	But some cases, we need to close connection manually. For that case, we can use this method.
+	**/
+	db, err := gdb.db.DB()
+	if err != nil {
+		return err
+	}
+	return db.Close()
 }
 
 func (gdb *gormDB) GetDB() *gorm.DB {


### PR DESCRIPTION
✨ feat(gorm.go): use GORM's DB method to get the underlying database connection and close it in Stop method The Stop method was added to close the database connection. The method uses GORM's DB method to get the underlying database connection and close it. This is necessary because from version 1.20, Jinzhu (GORM author) decided to eliminate the Close() method because GORM supports connection pooling. The best practice is to open the connection once and reuse it until the program exits. However, in some cases, we need to close the connection manually.